### PR TITLE
Fix typo in forcats pkg name

### DIFF
--- a/267-reorder-a-variable-in-ggplot2.Rmd
+++ b/267-reorder-a-variable-in-ggplot2.Rmd
@@ -50,9 +50,9 @@ data <- data.frame(
 
 
 
-# Method 1: the `Forecats` library {#forecats}
+# Method 1: the `forcats` library {#forcats}
 ***
-The [Forecats library](https://github.com/tidyverse/forcats) is a library from the [tidyverse](https://www.tidyverse.org/) especially made to handle factors in R. It provides a suite of useful tools that solve common problems with factors. The `fact_reorder()` function allows to reorder the factor (`data$name` for example) following the value of another column (`data$val` here).
+The [forcats library](https://github.com/tidyverse/forcats) is a library from the [tidyverse](https://www.tidyverse.org/) especially made to handle factors in R. It provides a suite of useful tools that solve common problems with factors. The `fct_reorder()` function allows to reorder the factor (`data$name` for example) following the value of another column (`data$val` here).
 
 ```{r, out.width=c('50%', '50%'), fig.show='hold', fig.width=5, fig.height=4}
 # load the library


### PR DESCRIPTION
Hi @holtzy :wave:,
Thank you so much for building the R Graph Gallery it is such an invaluable resource for all R users!
While browsing over it I noticed a typo on the name of the `forcats` R package in the 267th post. I've checked that this typo is not present anywhere else on the website.
