### PR TITLE
correct spacing around parenthesis; drop line

### DIFF
--- a/304-highlight-a-group-in-lollipop.Rmd
+++ b/304-highlight-a-group-in-lollipop.Rmd
@@ -68,8 +68,15 @@ data <- data %>%
   
 # Plot
 p <- ggplot(data, aes(x=x, y=y)) +
-  geom_segment( aes(x=x, xend=x, y=0, yend=y ), color=ifelse(data$x %in% c("A","D"), "orange", "grey"), size=ifelse(data$x %in% c("A","D"), 1.3, 0.7) ) +
-  geom_point( color=ifelse(data$x %in% c("A","D"), "orange", "grey"), size=ifelse(data$x %in% c("A","D"), 5, 2) ) +
+  geom_segment(
+    aes(x=x, xend=x, y=0, yend=y), 
+    color=ifelse(data$x %in% c("A","D"), "orange", "grey"), 
+    size=ifelse(data$x %in% c("A","D"), 1.3, 0.7)
+  ) +
+  geom_point(
+    color=ifelse(data$x %in% c("A","D"), "orange", "grey"), 
+    size=ifelse(data$x %in% c("A","D"), 5, 2)
+  ) +
   theme_ipsum() +
   coord_flip() +
   theme(


### PR DESCRIPTION
match the tidyverse style guide more closely by dropping each argument to a new line. I had to scroll to see the whole line on the website, and this makes it cleaner imo.