### PR TITLE
Section "Base R graph parameters": Sort bullet point list corresponding to image

### DIFF
--- a/6-graph-parameters-reminder.Rmd
+++ b/6-graph-parameters-reminder.Rmd
@@ -35,12 +35,12 @@ knitr::opts_chunk$set( warning=FALSE, message=FALSE)
 
 Base R offers many option to customize the chart appearance. Basically everthing is doable with those few options:
 
-- `cex` &rarr; shape size
 - `lwd` &rarr; line width
-- `col` &rarr; control colors
-- `lty` &rarr; line type
-- `pch` &rarr; marker shape
 - `type` &rarr; link between dots
+- `lty` &rarr; line type
+- `cex` &rarr; shape size
+- `col` &rarr; control colors
+- `pch` &rarr; marker shape
 
 <u>Note</u>: visit the [cheatsheet section](cheatsheet.html) for more.
 

--- a/6-graph-parameters-reminder.html
+++ b/6-graph-parameters-reminder.html
@@ -194,12 +194,12 @@
             Basically everthing is doable with those few options:
           </p>
           <ul>
-            <li><code>cex</code> → shape size</li>
             <li><code>lwd</code> → line width</li>
-            <li><code>col</code> → control colors</li>
-            <li><code>lty</code> → line type</li>
-            <li><code>pch</code> → marker shape</li>
             <li><code>type</code> → link between dots</li>
+            <li><code>lty</code> → line type</li>
+            <li><code>cex</code> → shape size</li>
+            <li><code>col</code> → control colors</li>
+            <li><code>pch</code> → marker shape</li>
           </ul>
           <p>
             <u>Note</u>: visit the


### PR DESCRIPTION
In the section [Base R graph parameters: a cheatsheet](https://r-graph-gallery.com/6-graph-parameters-reminder.html), I feel having the same order of the bullet points of the list on the left as in the image on the right, makes it much easier to find the single chart features in both the image and the list. 

| unsorted list (main branch) | sorted list (this branch / PR) | image |
| --- | --- | --- |
| ![6_chart_features_list](https://github.com/user-attachments/assets/6f5e16e8-5770-4df1-b9e7-1760582703ab) | ![6_chart_features_list_sorted](https://github.com/user-attachments/assets/3fa9f505-c840-477a-adf9-14c34a300fdf) | ![6_chart_features_image](https://github.com/user-attachments/assets/56c706db-2664-417b-90b7-515dd059884e) |

