### PR TITLE
6-graph-parameters-reminder: Remove outdated link to "cheatsheet section"

### DIFF
--- a/6-graph-parameters-reminder.Rmd
+++ b/6-graph-parameters-reminder.Rmd
@@ -42,8 +42,6 @@ Base R offers many option to customize the chart appearance. Basically everthing
 - `col` &rarr; control colors
 - `pch` &rarr; marker shape
 
-<u>Note</u>: visit the [cheatsheet section](cheatsheet.html) for more.
-
 </div>
 
 <br><br>

--- a/6-graph-parameters-reminder.html
+++ b/6-graph-parameters-reminder.html
@@ -201,10 +201,6 @@
             <li><code>col</code> → control colors</li>
             <li><code>pch</code> → marker shape</li>
           </ul>
-          <p>
-            <u>Note</u>: visit the
-            <a href="cheatsheet.html">cheatsheet section</a> for more.
-          </p>
         </div>
         <p><br /><br /></p>
         <div class="col-md-6 col-sm-12">


### PR DESCRIPTION
This PR removes a note pointing out a "cheatsheet" in "6-graph-parameters-reminder" as the "cheatsheet section" seems to be removed.

Related / Fixes issue #238 