### PR TITLE
Fix "Animation" link

### DIFF
--- a/index.html
+++ b/index.html
@@ -1058,7 +1058,7 @@
               <div class="captionPortfolio">Cheatsheets</div>
             </div>
             <div class="col-1-7 portfolio-item">
-              <a class="portfolio-link" href="cheatsheets.html">
+              <a class="portfolio-link" href="animation.html">
                 <img
                   class="img-fluid grey_on_hover"
                   src="img/section/anim150.gif"


### PR DESCRIPTION
The "Animation" link on the main page was linking to cheatsheets.html instead of animation.html